### PR TITLE
Switch to daisyUI themes instead of custom colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="night">
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -4,7 +4,6 @@
 
 
 body {
-  @apply bg-gradient-to-br from-20% to-90% from-slate-300 dark:from-slate-950 via-indigo-300 dark:via-indigo-950 to-sky-300 dark:to-sky-950 text-slate-900 dark:text-white;
   display: flex;
   min-height: 100vh;
 }
@@ -31,16 +30,8 @@ h4 {
   font-size: 1.2rem;
 }
 
-input {
-  @apply bg-gray-50 border border-gray-300 text-gray-900 focus:ring-blue-500 focus:border-blue-500 block w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 p-2.5 text-sm;
-}
-
-select {
-  @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
-}
-
-label.list-item-label:hover {
-  @apply bg-sky-950 text-white;
+input, select {
+  @apply text-sm block w-full p-2.5;
 }
 
 .indent {
@@ -52,13 +43,3 @@ label.list-item-label:hover {
   padding: .25rem 0;
 }
 
-a, summary {
-  @apply text-indigo-950 visited:text-indigo-900 dark:text-indigo-200 dark:visited:text-indigo-100;
-  text-decoration: none;
-  transition: 0.4s;
-  padding: 0 0.15rem;
-
-  &:hover, &:active, &:focus {
-    @apply bg-indigo-300 text-slate-950 font-bold #{!important};
-  }
-}

--- a/src/components/betterlist/BetterList.vue
+++ b/src/components/betterlist/BetterList.vue
@@ -22,17 +22,17 @@ const addTerm = () => {
 <template>
 <div class="flex flex-col w-full">
   <form class="form-grid mb-2" @submit.prevent="addTerm">
-    <label for="term" class="form-label1 text-sm font-medium text-gray-900 dark:text-white">Add item to list</label>
+    <label for="term" class="form-label1 text-sm font-medium">Add item to list</label>
     <input type="text" list="terms" id="term" name="term" placeholder="Item" v-model.trim="term" class="form-input1" />
     <datalist id="terms">
       <option v-for="(id, term) in store.termList" :key="id" :value="term">{{ term }}</option>
     </datalist>
-    <label for="selectedCategory" class="form-label2 text-sm font-medium text-gray-900 dark:text-white">Add to category</label>
-    <select id="selectedCategory" v-model="selectedCategory" class="form-input2 text-black p-2">
+    <label for="selectedCategory" class="form-label2 text-sm font-medium">Add to category</label>
+    <select id="selectedCategory" v-model="selectedCategory" class="form-input2 p-2">
       <option v-for="(category, id) in store.categoryList" :value="id" :key="id">{{ category.name }}</option>
     </select>
-    <button type="submit" class="form-button py-2 px-3 bg-cyan-500 text-white font-semibold">Add</button>
-    <RouterLink to="/betterlist/categories" class="form-link-gear text-xs bg-indigo-600">Manage categories &#9881;</RouterLink>
+    <button type="submit" class="form-button py-2 px-3 bg-primary text-white font-semibold">Add</button>
+    <RouterLink to="/betterlist/categories" class="form-link-gear text-xs bg-secondary">Manage categories &#9881;</RouterLink>
   </form>
 </div>
 <div class="flex w-full h-auto">

--- a/src/components/betterlist/CategoryCard.vue
+++ b/src/components/betterlist/CategoryCard.vue
@@ -42,9 +42,9 @@ const save = () => {
     <div class="card-actions justify-end">
       <template v-if="isEditState">
         <button @click="save" class="btn btn-primary">Save</button>
-        <button @click="toggle" class="btn">Cancel</button>
+        <button @click="toggle" class="btn btn-primary-content">Cancel</button>
       </template>
-      <button v-else @click="store.deleteCategory(category.id.toString())" class="btn">Delete</button>
+      <button v-else @click="store.deleteCategory(category.id.toString())" class="btn btn-primary-content">Delete</button>
     </div>
   </div>
 </div>

--- a/src/components/betterlist/CategoryManager.vue
+++ b/src/components/betterlist/CategoryManager.vue
@@ -15,9 +15,9 @@ const addCategory = () => {
 <template>
 <div class="flex flex-col w-full">
   <form class="grid grid-flow-col grid-column-4 lg:grid-column-5 grid-rows-[1fr_2fr_2fr] md:grid-rows-[1fr_2fr] mb-2" @submit.prevent="addCategory">
-    <label class="col-span-4 md:col-span-3 text-sm font-medium text-gray-900 dark:text-white" for="categoryName">Add category</label>
+    <label class="col-span-4 md:col-span-3 text-sm font-medium" for="categoryName">Add category</label>
     <input class="col-span-4 md:col-span-3" type="text" id="categoryName" name="categoryName" placeholder="Category" v-model.trim="categoryName" />
-    <button class="col-span-4 md:col-span-1 md:row-span-2 py-2 px-3 bg-cyan-500 text-white font-semibold" type="submit">Add</button>
+    <button class="col-span-4 md:col-span-1 md:row-span-2 py-2 px-3 bg-primary text-white font-semibold" type="submit">Add</button>
   </form>
 </div>
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">

--- a/src/components/map/DeliveryMap.vue
+++ b/src/components/map/DeliveryMap.vue
@@ -54,7 +54,7 @@ const retrieve = async (id: string) => {
 <div role="tablist" class="tabs tabs-lifted">
 
   <input v-model="currentTab" value="0" type="radio" name="mapTabs" role="tab" class="tab h-16 sm:h-8" aria-label="Mapbox Token Entry" />
-  <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+  <div role="tabpanel" class="tab-content bg-neutral border-base-300 rounded-box p-6">
     <form class="join w-full mb-1" @submit.prevent="submit">
       <input v-model.trim="mapStore.accessToken" :disabled="isLocked" :class="lockStyle" class="join-item" type="text" id="token" name="token" placeholder="Mapbox API Token" />
       <button type="submit" class="btn join-item whitespace-nowrap py-2 px-3 bg-cyan-500 text-white font-semibold">{{ isLocked ? 'Clear' : 'Initialize' }} Map</button>
@@ -62,14 +62,14 @@ const retrieve = async (id: string) => {
   </div>
 
   <input v-model="currentTab" value="1" :disabled="!isLocked" type="radio" name="mapTabs" role="tab" class="tab h-16 sm:h-8" aria-label="Address Search" />
-  <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+  <div role="tabpanel" class="tab-content bg-neutral border-base-300 rounded-box p-6">
     <form class="join w-full mb-1" @submit.prevent="suggest">
       <input v-model.trim="search.term" class="join-item" type="text" id="address" name="address" placeholder="Address" />
-      <button type="submit" class="btn join-item whitespace-nowrap py-2 px-3 bg-indigo-500 text-white font-semibold">Search</button>
+      <button type="submit" class="btn join-item whitespace-nowrap py-2 px-3 bg-secondary text-white font-semibold">Search</button>
     </form>
-    <div v-if="search.hasSuggestions" class="suggestions join join-vertical flex border border-indigo-500">
-      <div v-for="(suggestion, id) in search.suggestions" :key="id" class="flex flex-row justify-between items-center join-item join w-full dark:hover:bg-gray-700 dark:hover:text-white">
-        <span class="join-item paragraph">{{ suggestion.address }}</span>
+    <div v-if="search.hasSuggestions" class="suggestions join join-vertical flex border border-secondary">
+      <div v-for="(suggestion, id) in search.suggestions" :key="id" class="flex flex-row justify-between items-center join-item join w-full hover:bg-info-content">
+        <span class="join-item indent">{{ suggestion.address }}</span>
         <button class="btn btn-primary join-item" @click="retrieve(id.toString())">Show</button>
       </div>
     </div>
@@ -88,5 +88,9 @@ const retrieve = async (id: string) => {
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+.tab {
+  --tab-bg: oklch(var(--n));
 }
 </style>

--- a/src/components/nav/NavBar.vue
+++ b/src/components/nav/NavBar.vue
@@ -3,13 +3,13 @@ import ThemeToggle from './ThemeToggle.vue';
 </script>
 
 <template>
-<div class="navbar border-b border-indigo-700">
+<div class="navbar border-b border-secondary">
   <div class="navbar-start">
     <div class="dropdown">
       <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /></svg>
       </div>
-      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-30 p-2 shadow bg-indigo-200 dark:bg-slate-800 rounded-box w-52">
+      <ul tabindex="0" class="bg-base-100 border border-secondary menu menu-sm dropdown-content mt-3 z-30 p-2 shadow rounded-box w-52">
         <li><RouterLink :to="{ name: 'experiences' }">Experiences</RouterLink></li>
         <li>
           <summary>Side-projects</summary>
@@ -29,7 +29,7 @@ import ThemeToggle from './ThemeToggle.vue';
       <li>
         <details>
           <summary>Side-projects</summary>
-          <ul class="p-2 z-30 bg-indigo-200 dark:bg-slate-800">
+          <ul class="border border-secondary p-2 z-30">
             <li><RouterLink to="/betterlist">BetterList</RouterLink></li>
             <li><RouterLink to="/delivery">Delivery Optimization</RouterLink></li>
           </ul>

--- a/src/components/nav/ThemeToggle.vue
+++ b/src/components/nav/ThemeToggle.vue
@@ -1,31 +1,41 @@
 <script setup lang="ts">
-import { promiseTimeout, useDark, useToggle } from '@vueuse/core'
+import { watch, computed } from 'vue';
+import { useStorage } from '@vueuse/core';
 
-const isDark = useDark();
-const toggleDark = useToggle(isDark);
+const DEFAULT_THEME = 'night';
+const AVAILABLE_THEMES = [
+  'dark',
+  'synthwave',
+  'business',
+  'night',
+  'dracula',
+];
 
-const toggle = async () => {
-  await promiseTimeout(200);
-  toggleDark();
+const theme = useStorage('theme', DEFAULT_THEME);
+watch(theme, () => {
+  setTheme();
+});
+
+const setTheme = () => {
+  const html = document.querySelector('html');
+  html?.setAttribute('data-theme', theme.value);
+}
+
+const domTheme = computed(() => {
+  const html = document.querySelector('html');
+  return html?.getAttribute('data-theme');
+})
+
+// Change the theme on startup if we have a different one saved.
+if (theme.value !== domTheme.value) {
+  setTheme();
 }
 </script>
 
 <template>
-<label class="relative inline-flex items-center cursor-pointer swap swap-rotate">
-  <input type="checkbox" @click="toggle" class="sr-only peer">
-  <!-- Switch style from Flowbite -->
-  <div class="w-11 h-6 bg-gray-200
-    peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-indigo-300 dark:peer-focus:ring-indigo-800
-    rounded-full peer dark:bg-gray-700
-    peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white
-    after:content-[''] after:absolute after:top-[2px] after:start-[2px]
-    after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all
-    dark:border-gray-600 peer-checked:bg-indigo-600">
-  </div>
-  <!-- sun icon -->
-  <svg v-show="!isDark" class="swap-on fill-current ml-1 w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/></svg>
-  <!-- moon icon -->
-  <svg v-show="isDark" class="swap-off fill-current ml-1 w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z"/></svg>
-</label>
+
+<select v-model="theme" class="w-fit">
+  <option v-for="th in AVAILABLE_THEMES" :key="th" :value="th" :data-theme="th">{{ th }}</option>
+</select>
 
 </template>

--- a/src/stores/map.ts
+++ b/src/stores/map.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia';
-import { ref, computed, watch } from 'vue';
-import { useDark } from '@vueuse/core';
+import { ref } from 'vue';
 import mapboxgl, { Map, Marker } from 'mapbox-gl';
 
 interface Coordinates {
@@ -35,6 +34,8 @@ export {
   fromCoords,
 }
 
+const MAP_STYLE = 'mapbox://styles/mapbox/navigation-night-v1';
+
 export const useMapStore = defineStore('map', () => {
   const accessToken = ref('');
   const currentPlace = ref({} as Place);
@@ -44,24 +45,13 @@ export const useMapStore = defineStore('map', () => {
   const map = ref();
   const mapBox = ref();
 
-  const isDark = useDark();
-  const mapStyle = computed(() => `mapbox://styles/mapbox/navigation-${ isDark.value ? 'night' : 'day' }-v1`);
-  // Change the map style when darkmode is toggled
-  watch(isDark, () => {
-    if (map.value) {
-      // `diff: true` tries to only change the style and keep everything, but it prints warnings every time
-      map.value.setStyle(mapStyle.value, { diff: false });
-      // TODO: check if we need to re-add markers/elements to map (https://docs.mapbox.com/mapbox-gl-js/example/style-switch/)
-    }
-  });
-
   const init = (mb: any) => {
     // Copy mapbox template ref from component
     mapBox.value = mb.value;
     mapboxgl.accessToken = accessToken.value;
     map.value = new Map({
       container: mapBox.value,
-      style: mapStyle.value,
+      style: MAP_STYLE,
       // lng,lat
       center: [-83.653824, 41.562829],
       zoom: 9,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,5 +9,14 @@ module.exports = {
     extend: {},
   },
   plugins: [require("daisyui")],
+  daisyui: {
+    themes: [
+      "dark",
+      "synthwave",
+      "business",
+      "night",
+      "dracula",
+    ],
+  },
 }
 


### PR DESCRIPTION
- Default theme is night, themes will save to localstorage and update automatically on refresh
- Not including all themes as some change the border and stuff and it makes some forms wrong? Also only want the cool ones ;D
- Changed colors to accept the themes default or to primary/secondary/etc style so it stays the same cohesiveness across themes
- No more gradient, but the site is miles more readable
- Remove day/night map switch that I spent so long on as it doesn't make sense with current theme options and it's functionally useless

Fixes #7 - No icon switch necessary when using the select box